### PR TITLE
Fix authentication

### DIFF
--- a/gabber/client.py
+++ b/gabber/client.py
@@ -310,7 +310,7 @@ class Client:
             logger.error(f"Failed request to login page: {str(e)}")
             return None
 
-        if not sess_req.cookies.get("_session_id"):
+        if not sess_req.cookies.get("_gabsocial_session"):
             raise ValueError("Invalid gab.com credentials provided!")
 
         return sess_req.cookies


### PR DESCRIPTION
Apparently the cookie's name for session auth changed, it's now "_gabsocial_session".