### PR TITLE
Flatten output

### DIFF
--- a/gabber/client.py
+++ b/gabber/client.py
@@ -631,22 +631,9 @@ def followers(ctx, followers_file: string, id: int):
     if id is None:
         id = client.find_latest_user()["id"]
 
-    followers = client.pull_followers(id)
     with open(followers_file, "w") as followers_file:
-        for follower in followers:
-            print(
-                json.dumps(follower, default=json_set_default),
-                file=followers_file,
-                flush=True,
-            )
-
-    # TODO: remove this counter
-    round = 0
-    with open(followers_file, "w") as followers_file:
-        follow_gen = client.pull_follow(id, endpoint="followers")
-        for followers in follow_gen:
-            logger.debug(f"Print round {round}")
-            round += 1
+        follow_generator = client.pull_follow(id, endpoint="followers")
+        for followers in follow_generator:
             for account in followers:
                 print(
                     json.dumps(account, default=json_set_default),
@@ -675,13 +662,9 @@ def following(ctx, following_file: string, id: int):
     if id is None:
         id = client.find_latest_user()["id"]
 
-    # TODO: remove this counter
-    round = 0
     with open(following_file, "w") as following_file:
-        follow_gen = client.pull_follow(id, endpoint="following")
-        for following in follow_gen:
-            logger.debug(f"Print round {round}")
-            round += 1
+        follow_generator = client.pull_follow(id, endpoint="following")
+        for following in follow_generator:
             for account in following:
                 print(
                     json.dumps(account, default=json_set_default),


### PR DESCRIPTION
Output for CLI arguments `followers` and `following` should now be JSONL formatted. 

Also, each pull is written to disk periodically, so it is no longer required for the entire pull to complete in order to have access to at least a partial set of records.